### PR TITLE
Add comment: what if INPUT.MIN_SIZE_TRAIN==0

### DIFF
--- a/detectron2/config/defaults.py
+++ b/detectron2/config/defaults.py
@@ -46,7 +46,7 @@ _C.MODEL.PIXEL_STD = [1.0, 1.0, 1.0]
 # INPUT
 # -----------------------------------------------------------------------------
 _C.INPUT = CN()
-# Size of the smallest side of the image during training
+# Size of the smallest side of the image during training.  Set to zero to disable resize in training.
 _C.INPUT.MIN_SIZE_TRAIN = (800,)
 # Sample size of smallest side by choice or random selection from range give by
 # INPUT.MIN_SIZE_TRAIN


### PR DESCRIPTION
INPUT.MIN_SIZE_TEST was documented, but INPUT.MIN_SIZE_TRAIN was not.

Thanks for your contribution!

If you're sending a large PR (e.g., >50 lines),
please open an issue first about the feature / bug, and indicate how you want to contribute.
See more at https://detectron2.readthedocs.io/notes/contributing.html#pull-requests
about how we handle PRs.

Before submitting a PR, please run `dev/linter.sh` to lint the code.
